### PR TITLE
Satisfy PyLint wrong-import-order

### DIFF
--- a/examples/extended_bus_simpletest.py
+++ b/examples/extended_bus_simpletest.py
@@ -4,8 +4,8 @@ Adafruit BME280 Sensor using this library and just
 the I2C bus number.
 """
 
-from adafruit_extended_bus import ExtendedI2C as I2C
 import adafruit_bme280
+from adafruit_extended_bus import ExtendedI2C as I2C
 
 # Create library object using our Extended Bus I2C port
 i2c = I2C(1)  # Device is /dev/i2c-1


### PR DESCRIPTION
Discovered in: https://github.com/adafruit/Adafruit_Python_Extended_Bus/pull/4